### PR TITLE
return 0 when score or reviews is undefined

### DIFF
--- a/lib/scores/difficulty.js
+++ b/lib/scores/difficulty.js
@@ -65,7 +65,7 @@ function build (store) {
   * Score the average rating among the top apps.
   */
   function getRating (keyword, apps) {
-    const avg = R.sum(R.pluck('score', apps)) / apps.length;
+    const avg = R.sum(R.pluck('score', apps).map(score => score === undefined ? 0 : score)) / apps.length;
     return {
       avg,
       score: avg * 2

--- a/lib/stores/itunes.js
+++ b/lib/stores/itunes.js
@@ -36,7 +36,7 @@ function buildStore (defaults) {
     suggest: (opts) => wrapped(itunes.suggest)(opts).then(R.pluck('term')),
 
     getInstallsScore: function (apps) {
-      const avg = R.sum(R.pluck('reviews', apps)) / apps.length;
+      const avg = R.sum(R.pluck('reviews', apps).map(review => review === undefined ? 0 : review)) / apps.length;
       const max = 100000;
       const score = calc.zScore(max, avg);
       return {avg, score};


### PR DESCRIPTION
For keyword scores overall difficulty and traffic score may be null. This happens if itunes returns apps with  'score' or 'reviews' fields undefined (for example, if an app doesn't have reviews). Hence, it affects overall difficulty and traffic score calculation.

Example result:
```
"difficulty": {
    "titleMatches": {
      "exact": 0,
      "broad": 0,
      "partial": 0,
      "none": 10,
      "score": 0
    },
    "competitors": {
      "count": 1,
      "score": 1.09
    },
    "installs": {
      "avg": null
      "score": null
    },
    "rating": {
      "avg": null
      "score": null
    },
    "age": {
      "avgDaysSinceUpdated": 557.1,
      "score": 1
    },
    "score": null
  }
```